### PR TITLE
Fix flightmode issue

### DIFF
--- a/src/main/java/ch/ruinformatique/fortytwoauthcraft/events/AuthEventHandler.java
+++ b/src/main/java/ch/ruinformatique/fortytwoauthcraft/events/AuthEventHandler.java
@@ -27,7 +27,7 @@ public class AuthEventHandler implements Listener {
 			Player player = event.getPlayer();
 			Location from = event.getFrom();
 			Location to = event.getTo();
-			if (from.getX() != to.getX() || from.getZ() != to.getZ() || from.getY() != to.getY()) {
+			if (from.getX() != to.getX() || from.getZ() != to.getZ()) {
 				player.teleport(from);
 			}
 		}

--- a/src/main/java/ch/ruinformatique/fortytwoauthcraft/events/AuthEventHandler.java
+++ b/src/main/java/ch/ruinformatique/fortytwoauthcraft/events/AuthEventHandler.java
@@ -27,7 +27,7 @@ public class AuthEventHandler implements Listener {
 			Player player = event.getPlayer();
 			Location from = event.getFrom();
 			Location to = event.getTo();
-			if (from.getX() != to.getX() || from.getZ() != to.getZ()) {
+			if (from.getX() != to.getX() || from.getZ() != to.getZ() || from.getY() < to.getY()) {
 				player.teleport(from);
 			}
 		}


### PR DESCRIPTION
A temporary fix prevents players from being kicked due to flight mode. This fix does not cause the player to freeze while falling. Ideally, I would like to also freeze the player during falls, but this would necessitate complex flight mode triggering involving database files.