### PR TITLE
fix: Player getting damaged by fireworks on login

### DIFF
--- a/src/main/java/ch/ruinformatique/fortytwoauthcraft/events/AuthEventHandler.java
+++ b/src/main/java/ch/ruinformatique/fortytwoauthcraft/events/AuthEventHandler.java
@@ -76,7 +76,9 @@ public class AuthEventHandler implements Listener {
 	@EventHandler
 	public void onEntityDamage(EntityDamageEvent event) {
 		if (event.getEntity() instanceof Player) {
-			event.setCancelled(!PlayerVerificationManager.isPlayerVerified(((Player) event.getEntity()).getUniqueId()));
+			if (!PlayerVerificationManager.isPlayerVerified(((Player) event.getEntity()).getUniqueId())) {
+				event.setCancelled(true);
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolve the issue of players being harmed by fireworks upon login. The onEntityDamage event was reactivating damage previously negated by the onEntityDamageByEntity event.